### PR TITLE
chore: 소스 코드에 JSX Pragma를 사용하지 않더라도 JSX 표현식에 `jsx`를 사용하도록 함 (#38)

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+EXTEND_ESLINT=true

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,6 +39,7 @@ module.exports = {
     'react/jsx-filename-extension': ['error', { extensions: ['.tsx'] }],
     'react/jsx-one-expression-per-line': 'off',
     'react/prop-types': 'off',
+    'react/react-in-jsx-scope': 'off',
     'simple-import-sort/sort': 'error',
     'sort-imports': 'off',
     '@typescript-eslint/no-use-before-define': ['error', { variables: false, functions: false }],

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -2,7 +2,7 @@ import { Global } from '@emotion/core';
 import { ConnectedRouter } from 'connected-react-router';
 import { ThemeProvider } from 'emotion-theming';
 import { History } from 'history';
-import React, { Suspense } from 'react';
+import { Suspense } from 'react';
 import { Route, Switch } from 'react-router-dom';
 
 import { RouteEnum } from '../constants';

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const Home: React.FC = () => <div>Home</div>;
 
 export default Home;

--- a/src/views/Home/components/Hello/Hello.tsx
+++ b/src/views/Home/components/Hello/Hello.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const Hello: React.FC = () => <div>Hello</div>;
 
 export default Hello;

--- a/src/views/NotFound/NotFound.tsx
+++ b/src/views/NotFound/NotFound.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const NotFound: React.FC = () => <div>NotFound</div>;
 
 export default NotFound;

--- a/src/views/components/Spinner/Spinner.tsx
+++ b/src/views/components/Spinner/Spinner.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const Spinner: React.FC = () => <div>Loading...</div>;
 
 export default Spinner;


### PR DESCRIPTION
### Short description

컴포넌트 파일에서 JSX Pragma를 사용하지 않더라도 JSX 표현식에 `React.createElement` 대신 `jsx`를 사용하도록 함

### Proposed changes

 - ESLint 규칙에 react/react-in-jsx-scope을 `off`로 설정
 - CRA ESLint 규칙을 덮어씌우기 위해 EXTEND_ESLINT 환경변수 추가
 - JSX Pragma를 사용하던 코드를 제거

### Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionally)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Test
- [ ] Documentation
- [ ] Refactoring
- [x] Chore

### How to test (Optional)

- 개발 서버 실행 (yarn start)
- 앱이 깨지지 않고 동작하는지 확인

### Reference (Optional)

- Fixes #38 