### PR TITLE
fix: 파트너 초대 화면에서 fragments 에러 수정 (#51)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,7 @@ module.exports = {
     'react-hooks/exhaustive-deps': 'warn',
     'react-hooks/rules-of-hooks': 'error',
     'react/jsx-filename-extension': ['error', { extensions: ['.tsx'] }],
+    'react/jsx-fragments': 'off',
     'react/jsx-one-expression-per-line': 'off',
     'react/jsx-props-no-spreading': 'off',
     'react/prop-types': 'off',

--- a/src/views/Invitation/Invitation.tsx
+++ b/src/views/Invitation/Invitation.tsx
@@ -1,4 +1,5 @@
 import { css, SerializedStyles } from '@emotion/core';
+import { Fragment } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import Theme from '../../models/Theme';
@@ -22,7 +23,7 @@ const Invitation: React.FC = () => {
   const handleLinkClick = (): void => {};
 
   return (
-    <>
+    <Fragment>
       <Header>
         <Button type="button" onClick={handlePrevClick}>
           이전
@@ -43,7 +44,7 @@ const Invitation: React.FC = () => {
         </div>
         <DotsIndicator totalPages={2} currentPage={2} />
       </Layout>
-    </>
+    </Fragment>
   );
 };
 


### PR DESCRIPTION
### Short description

fragments 축약 문법 사용으로 인해 발생하는 에러를 해결함

### Proposed changes

- emotion babel 플러그인 사용 시 fragments 축약 문법을 사용할 수 없는 문제로, `<>`를 `<Fragment>`로 변경함
- `<Fragment>` 대신 `<>`을 사용하도록 하는 eslint rule을 off함

### Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionally)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Test
- [ ] Documentation
- [ ] Refactoring

### How to test (Optional)

- 개발 서버에서 `/invitation` 경로로 접속
- 화면이 정상적으로 렌더링되는지 확인

### Reference (Optional)

- Fixes #51 
